### PR TITLE
fix linux mingw-w64 cross compile link error

### DIFF
--- a/uing/rawui.nim
+++ b/uing/rawui.nim
@@ -94,7 +94,7 @@ else:
       {.passL: "-lcomctl32".}
       {.passL: "-ld2d1".}
       {.passL: "-ldwrite".}
-      {.passL: "-luxTheme".}
+      {.passL: "-luxtheme".}
       {.passL: "-lusp10".}
       {.passL: "-lgdi32".}
       {.passL: "-luser32".}


### PR DESCRIPTION
Cross-compiling with mingw-w64 on Linux, DLL names are lowercase and case-sensitive. This should not affect native windows compiles but you may want to give it a brief test. Thanks for uing!!!